### PR TITLE
Remove invalid path check

### DIFF
--- a/llbuild.xcodeproj/project.pbxproj
+++ b/llbuild.xcodeproj/project.pbxproj
@@ -2289,8 +2289,8 @@
 				1484D1DA2094509E00D3830F /* LICENSE.txt */,
 				E1A223FC19F990E60059043E /* README.md */,
 				1484D1DB209450A600D3830F /* Vagrantfile */,
-				E1A223F219F98F1C0059043E /* Products */,
 				E13B5E411A00395300EA0405 /* Frameworks */,
+				E1A223F219F98F1C0059043E /* Products */,
 			);
 			indentWidth = 2;
 			sourceTree = "<group>";

--- a/products/llbuildSwift/BuildSystemBindings.swift
+++ b/products/llbuildSwift/BuildSystemBindings.swift
@@ -1213,12 +1213,6 @@ public final class BuildSystem {
     }
 
     private func fsGetFileInfo(_ path: String, _ info: UnsafeMutablePointer<llb_fs_file_info_t>) {
-        // Ignore invalid paths.
-        guard path.first == "/" else {
-            info.pointee = llb_fs_file_info_t()
-            return
-        }
-
         // If the path doesn't exist, it is missing.
         let fs = delegate.fs!
         guard let s = try? fs.getFileInfo(path).statBuf else {


### PR DESCRIPTION
These paths are expected to be absolute, but that should be handled by the `fs` object.