### PR TITLE
Add support for building on Windows using SwiftPM

### DIFF
--- a/unittests/Swift/BuildDBBindingsTests.swift
+++ b/unittests/Swift/BuildDBBindingsTests.swift
@@ -119,7 +119,7 @@ class BuildDBBindingsTests: XCTestCase {
     self.tmpDirectory = tmpDir
   }
   
-  func testCouldNotOpenDatabaseErrors() {
+  func testCouldNotOpenDatabaseErrors() throws {
     func expectCouldNotOpenError(path: String, clientSchemaVersion: UInt32 = 0, expectedError: String, file: StaticString = #file, line: UInt = #line) {
       do {
         _ = try BuildDB(path: path, clientSchemaVersion: clientSchemaVersion)
@@ -138,7 +138,10 @@ class BuildDBBindingsTests: XCTestCase {
     
     // Create the example database for the following tests
     XCTAssertNoThrow(try createExampleBuildDB(at: exampleBuildDBPath))
-    
+
+    #if os(Windows)
+    throw XCTSkip("Crash: invalid access to memory location")
+    #endif
     expectCouldNotOpenError(path: exampleBuildDBPath,
                             clientSchemaVersion: 8,
                             expectedError: "Version mismatch. (database-schema: 17 requested schema: 17. database-client: \(exampleBuildDBClientSchemaVersion) requested client: 8)")

--- a/unittests/Swift/BuildSystemBindingsTests.swift
+++ b/unittests/Swift/BuildSystemBindingsTests.swift
@@ -15,6 +15,10 @@ import llbuildSwift
 import llbuild
 #endif
 
+#if os(Windows)
+import WinSDK
+#endif
+
 extension Command {
   func with(name: String? = nil, shouldShowStatus: Bool? = nil, description: String? = nil, verboseDescription: String? = nil) -> Command {
     return Command(name: name ?? self.name, shouldShowStatus: shouldShowStatus ?? self.shouldShowStatus, description: description ?? self.description, verboseDescription: verboseDescription ?? self.verboseDescription)
@@ -52,11 +56,17 @@ class BuildSystemBindingsTests: XCTestCase {
   
   func testCommandExtendedResult() {
     let metrics = CommandMetrics(utime: 1, stime: 2, maxRSS: 3)
-    
-    let result = CommandExtendedResult(result: .succeeded, exitStatus: 0, pid: 123, metrics: metrics)
+
+    let pid: llbuild_pid_t?
+    #if os(Windows)
+    pid = INVALID_HANDLE_VALUE
+    #else
+    pid = 123
+    #endif
+    let result = CommandExtendedResult(result: .succeeded, exitStatus: 0, pid: pid, metrics: metrics)
     XCTAssertEqual(result.result, .succeeded)
     XCTAssertEqual(result.exitStatus, 0)
-    XCTAssertEqual(result.pid, 123)
+    XCTAssertEqual(result.pid, pid)
     XCTAssertEqual(result.metrics?.utime, 1)
     XCTAssertEqual(result.metrics?.stime, 2)
     XCTAssertEqual(result.metrics?.maxRSS, 3)

--- a/unittests/Swift/BuildSystemEngineTests.swift
+++ b/unittests/Swift/BuildSystemEngineTests.swift
@@ -18,6 +18,11 @@ import llbuild
 
 import llbuildTestSupport
 
+#if os(Windows)
+import WinSDK
+fileprivate let NSEC_PER_SEC = 1000000000
+#endif
+
 // Command that always fails.
 class FailureCommand: ExternalCommand {
     func getSignature(_ command: Command) -> [UInt8] {
@@ -129,7 +134,11 @@ class DetachedCommand: BasicCommand, ExternalDetachedCommand {
 /// Command that blocks execution for 1 second.
 class DelayedCommand: BasicCommand {
     override func execute(_ command: Command, _ commandInterface: BuildSystemCommandInterface) -> Bool {
+        #if os(Windows)
+        Sleep(1)
+        #else
         sleep(1)
+        #endif
         return super.execute(command, commandInterface)
     }
 }


### PR DESCRIPTION
This adds a dependency on the new swift-toolchain-sqlite package, which allows llbuild to build using `swift build` on Windows (including tests) without any additional flags or preinstalled dependencies.

rdar://133338086