### PR TITLE
Improve build performance by a factor of $CORE_COUNT

### DIFF
--- a/lib/Basic/PlatformUtility.cpp
+++ b/lib/Basic/PlatformUtility.cpp
@@ -220,8 +220,7 @@ int sys::write(int fileHandle, void *destinationBuffer,
 // Get the current process' open file limit. Returns -1 on failure.
 llbuild_rlim_t sys::getOpenFileLimit() {
 #if defined(_WIN32)
-  int value = _getmaxstdio();
-  return std::min(0, value);
+  return _getmaxstdio();
 #else
   struct rlimit rl;
   int ret = getrlimit(RLIMIT_NOFILE, &rl);


### PR DESCRIPTION
This fixes a regression introduced by #597, where the following line 3900ed4#diff-bd65cf12ed29b52c530ff04d2c678eb66883eddfcb44d5dbb8fe499f25865e93R219 presumably meant to use std::max instead of std::min.

The impact of this is that estimateTaskLimits falls back to a default case of returning only a single lane, regardless of the number of requested lanes, and consequently all builds are serialized.

Now, we simply return the value of _getmaxstdio directly. The documentation does not indicate that this function can fail or return a negative or zero value, and attempting to set the value with _setmaxstdio will terminate the process if given any value less than _IOB_ENTRIES (3).

Closes: #936