### PR TITLE
Link SQLite3 on Android and switch one import back to the Android overlay

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -87,7 +87,7 @@ let package = Package(
             ],
             path: "lib/Core",
             linkerSettings: [
-                .linkedLibrary("sqlite3", .when(platforms: [.macOS, .iOS, .tvOS, .watchOS, .visionOS, .macCatalyst, .linux]))
+                .linkedLibrary("sqlite3", .when(platforms: [.macOS, .iOS, .tvOS, .watchOS, .visionOS, .macCatalyst, .linux, .android]))
             ]
         ),
         .target(

--- a/products/llbuildSwift/BuildSystemBindings.swift
+++ b/products/llbuildSwift/BuildSystemBindings.swift
@@ -17,8 +17,8 @@ import WinSDK
 import Glibc
 #elseif canImport(Musl)
 import Musl
-#elseif canImport(Bionic)
-import Bionic
+#elseif canImport(Android)
+import Android
 #else
 #error("Missing libc or equivalent")
 #endif
@@ -1293,7 +1293,7 @@ public final class BuildSystem {
         #elseif os(Windows)
         info.pointee.mod_time.seconds = UInt64(s.st_mtime)
         info.pointee.mod_time.nanoseconds = 0
-        #elseif canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+        #elseif canImport(Glibc) || canImport(Musl) || canImport(Android)
         info.pointee.mod_time.seconds = UInt64(s.st_mtim.tv_sec)
         info.pointee.mod_time.nanoseconds = UInt64(s.st_mtim.tv_nsec)
         #else


### PR DESCRIPTION
The package manifest was recently updated, and the trunk 6.1 compiler recently started complaining that this larger Android overlay is needed instead.