### PR TITLE
Add some feature flags to control use of optional features in the build

### DIFF
--- a/include/llvm/Config/config.h
+++ b/include/llvm/Config/config.h
@@ -267,7 +267,7 @@
 #define HAVE_SYS_TYPES_H 1
 
 /* Define if the setupterm() function is supported this platform. */
-#if defined(__APPLE__) && TARGET_OS_IPHONE
+#if (defined(__APPLE__) && TARGET_OS_IPHONE) || defined(LLBUILD_NO_TERMINFO)
 #undef HAVE_TERMINFO
 #else
 #define HAVE_TERMINFO 1

--- a/unittests/TestSupport/XCTestCase+Extensions.swift
+++ b/unittests/TestSupport/XCTestCase+Extensions.swift
@@ -6,6 +6,7 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
+#if canImport(XCTest)
 import XCTest
 
 @available(macOS 10.15, *)
@@ -56,3 +57,4 @@ public extension XCTestCase {
         return filePath
     }
 }
+#endif


### PR DESCRIPTION
This will allow building llbuild with a Swift Static SDK using Musl libc, using SwiftPM.