### PR TITLE
[llbuild3] Fix an issue which caused action cache misses to prevent b…

### DIFF
--- a/src/llbuild3/core/ActionCache.swift
+++ b/src/llbuild3/core/ActionCache.swift
@@ -44,6 +44,9 @@ extension TActionCache {
             let bytes = try value.serializedData()
             handler(std.string(fromData: bytes), std.string())
             return
+          } else {
+            handler(std.string(), std.string())
+            return
           }
         } catch {
           let err: TError


### PR DESCRIPTION
…uilds from completing.

The ExtActionCache implementation for the TActionCache protocol failed to call the callback on a cache miss. This meant that cache misses, as are the case in fully-clean builds, would never allow the build to proceed to any actual work.

This commit resolves #958.