### PR TITLE
[llbuild3] Add support for passing a TCASDatabase to TEngine.

### DIFF
--- a/products/llbuild3/SwiftAdaptors.hpp
+++ b/products/llbuild3/SwiftAdaptors.hpp
@@ -128,6 +128,7 @@ struct ExtCASDatabase {
 
 class CASDatabase;
 typedef std::shared_ptr<CASDatabase> CASDatabaseRef;
+LLBUILD3_EXPORT CASDatabaseRef makeExtCASDatabase(ExtCASDatabase extCASDB);
 LLBUILD3_EXPORT CASDatabaseRef makeInMemoryCASDatabase();
 
 struct ExtActionCache {

--- a/src/llbuild3/core/Engine.swift
+++ b/src/llbuild3/core/Engine.swift
@@ -391,9 +391,13 @@ extension TEngineConfig {
 public class TEngine {
   private var eng: llbuild3.core.EngineRef
 
-  convenience public init (config: TEngineConfig = TEngineConfig(), actionCache: TActionCache? = nil, baseRuleProvider: TRuleProvider) throws {
-    // FIXME: move cas outside
-    let tcas = llbuild3.core.makeInMemoryCASDatabase()
+  convenience public init (config: TEngineConfig = TEngineConfig(), casDB: TCASDatabase? = nil, actionCache: TActionCache? = nil, baseRuleProvider: TRuleProvider) throws {
+    let tcas: llbuild3.core.CASDatabaseRef
+    if let casDB {
+      tcas = llbuild3.core.makeExtCASDatabase(casDB.extCASDatabase())
+    } else {
+      tcas = llbuild3.core.CASDatabaseRef()
+    }
 
     let tcache: llbuild3.core.ActionCacheRef
     if let cache = actionCache {


### PR DESCRIPTION
Exposed the existing `makeExtCASDatabase` function to Swift via SwiftAdaptors.hpp. Added a `casDB` parameter to `TEngine`'s main initializer, and used `makeExtCASDatabase` to make the necessary `CASDatabaseRef` when `casDB` is not nil.

This matches the behavior of the `TActionCache?` parameter to `TEngine`'s main initializer.

This commit resolves #959.