### PR TITLE
build: add additional target exports for static linking

### DIFF
--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -20,3 +20,5 @@ if(CMAKE_SYSTEM_NAME STREQUAL Windows)
   target_link_libraries(llbuildBasic PUBLIC
     ShLwApi.lib)
 endif()
+
+set_property(GLOBAL APPEND PROPERTY LLBuild_EXPORTS llbuildBasic)

--- a/lib/BuildSystem/CMakeLists.txt
+++ b/lib/BuildSystem/CMakeLists.txt
@@ -15,3 +15,5 @@ target_link_libraries(llbuildBuildSystem PRIVATE
   llbuildCore
   llbuildBasic
   llvmSupport)
+
+set_property(GLOBAL APPEND PROPERTY LLBuild_EXPORTS llbuildBuildSystem)

--- a/lib/Core/CMakeLists.txt
+++ b/lib/Core/CMakeLists.txt
@@ -11,3 +11,5 @@ target_link_libraries(llbuildCore PRIVATE
   llbuildBasic
   llvmSupport
   SQLite::SQLite3)
+
+set_property(GLOBAL APPEND PROPERTY LLBuild_EXPORTS llbuildCore)

--- a/lib/Ninja/CMakeLists.txt
+++ b/lib/Ninja/CMakeLists.txt
@@ -8,3 +8,5 @@ add_llbuild_library(llbuildNinja STATIC
 target_link_libraries(llbuildNinja PRIVATE
   llbuildBasic
   llvmSupport)
+
+set_property(GLOBAL APPEND PROPERTY LLBuild_EXPORTS llbuildNinja)

--- a/lib/llvm/Demangle/CMakeLists.txt
+++ b/lib/llvm/Demangle/CMakeLists.txt
@@ -2,3 +2,5 @@ add_llbuild_library(LLVMDemangle STATIC
     ItaniumDemangle.cpp
     MicrosoftDemangle.cpp
 )
+
+set_property(GLOBAL APPEND PROPERTY LLBuild_EXPORTS LLVMDemangle)

--- a/lib/llvm/Support/CMakeLists.txt
+++ b/lib/llvm/Support/CMakeLists.txt
@@ -67,3 +67,5 @@ endif()
 if(${CMAKE_SYSTEM_NAME} MATCHES "Android|Darwin|Linux|FreeBSD")
   target_link_libraries(llvmSupport PRIVATE curses)
 endif()
+
+set_property(GLOBAL APPEND PROPERTY LLBuild_EXPORTS llvmSupport)

--- a/products/libllbuild/CMakeLists.txt
+++ b/products/libllbuild/CMakeLists.txt
@@ -56,6 +56,7 @@ install(TARGETS libllbuild
   LIBRARY DESTINATION lib${LLBUILD_LIBDIR_SUFFIX}
   RUNTIME DESTINATION bin
   COMPONENT libllbuild)
+set_property(GLOBAL APPEND PROPERTY LLBuild_EXPORTS libllbuild)
 
 add_custom_target(install-libllbuild
                   DEPENDS libllbuild


### PR DESCRIPTION
When building with llbuild using statically linked libraries, we need to export additional targets to ensure that the full closure is available to consumers. This is meant to support building swift-driver against a statically linked library form of llbuild to allow using the early swift-driver on Windows.