### PR TITLE
Revert "build: add additional target exports for static linking"

### DIFF
--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -20,5 +20,3 @@ if(CMAKE_SYSTEM_NAME STREQUAL Windows)
   target_link_libraries(llbuildBasic PUBLIC
     ShLwApi.lib)
 endif()
-
-set_property(GLOBAL APPEND PROPERTY LLBuild_EXPORTS llbuildBasic)

--- a/lib/BuildSystem/CMakeLists.txt
+++ b/lib/BuildSystem/CMakeLists.txt
@@ -15,5 +15,3 @@ target_link_libraries(llbuildBuildSystem PRIVATE
   llbuildCore
   llbuildBasic
   llvmSupport)
-
-set_property(GLOBAL APPEND PROPERTY LLBuild_EXPORTS llbuildBuildSystem)

--- a/lib/Core/CMakeLists.txt
+++ b/lib/Core/CMakeLists.txt
@@ -11,5 +11,3 @@ target_link_libraries(llbuildCore PRIVATE
   llbuildBasic
   llvmSupport
   SQLite::SQLite3)
-
-set_property(GLOBAL APPEND PROPERTY LLBuild_EXPORTS llbuildCore)

--- a/lib/Ninja/CMakeLists.txt
+++ b/lib/Ninja/CMakeLists.txt
@@ -8,5 +8,3 @@ add_llbuild_library(llbuildNinja STATIC
 target_link_libraries(llbuildNinja PRIVATE
   llbuildBasic
   llvmSupport)
-
-set_property(GLOBAL APPEND PROPERTY LLBuild_EXPORTS llbuildNinja)

--- a/lib/llvm/Demangle/CMakeLists.txt
+++ b/lib/llvm/Demangle/CMakeLists.txt
@@ -2,5 +2,3 @@ add_llbuild_library(LLVMDemangle STATIC
     ItaniumDemangle.cpp
     MicrosoftDemangle.cpp
 )
-
-set_property(GLOBAL APPEND PROPERTY LLBuild_EXPORTS LLVMDemangle)

--- a/lib/llvm/Support/CMakeLists.txt
+++ b/lib/llvm/Support/CMakeLists.txt
@@ -67,5 +67,3 @@ endif()
 if(${CMAKE_SYSTEM_NAME} MATCHES "Android|Darwin|Linux|FreeBSD")
   target_link_libraries(llvmSupport PRIVATE curses)
 endif()
-
-set_property(GLOBAL APPEND PROPERTY LLBuild_EXPORTS llvmSupport)

--- a/products/libllbuild/CMakeLists.txt
+++ b/products/libllbuild/CMakeLists.txt
@@ -56,7 +56,6 @@ install(TARGETS libllbuild
   LIBRARY DESTINATION lib${LLBUILD_LIBDIR_SUFFIX}
   RUNTIME DESTINATION bin
   COMPONENT libllbuild)
-set_property(GLOBAL APPEND PROPERTY LLBuild_EXPORTS libllbuild)
 
 add_custom_target(install-libllbuild
                   DEPENDS libllbuild


### PR DESCRIPTION
Reverts swiftlang/swift-llbuild#966

This seems to be causing a CI failure, reverting to unblock CI.