### PR TITLE
build: rename `LLVMDemangle` to `llvmDemangle`

### DIFF
--- a/lib/llvm/Demangle/CMakeLists.txt
+++ b/lib/llvm/Demangle/CMakeLists.txt
@@ -1,6 +1,6 @@
-add_llbuild_library(LLVMDemangle STATIC
+add_llbuild_library(llvmDemangle STATIC
     ItaniumDemangle.cpp
     MicrosoftDemangle.cpp
 )
 
-set_property(GLOBAL APPEND PROPERTY LLBuild_EXPORTS LLVMDemangle)
+set_property(GLOBAL APPEND PROPERTY LLBuild_EXPORTS llvmDemangle)

--- a/lib/llvm/Support/CMakeLists.txt
+++ b/lib/llvm/Support/CMakeLists.txt
@@ -55,7 +55,7 @@ raw_ostream.cpp
 
 
 target_link_libraries(llvmSupport PRIVATE
-  LLVMDemangle
+  llvmDemangle
   Threads::Threads
   ${CMAKE_DL_LIBS})
 

--- a/tests/Examples/buildsystem-capi.llbuild
+++ b/tests/Examples/buildsystem-capi.llbuild
@@ -1,6 +1,6 @@
 # Check that the BuildSystem C API example builds and runs correctly.
 #
-# RUN: %clangxx -o %t.exe -x c++ %{srcroot}/examples/c-api/buildsystem/main.c -I %{srcroot}/products/libllbuild/include -lllbuild -lllbuildBuildSystem -lllbuildCore -lllbuildBasic -lllvmSupport -lLLVMDemangle -L %{llbuild-lib-dir} -Werror -Xlinker %{sqlite} %{curses} %{threads} %{dl}
+# RUN: %clangxx -o %t.exe -x c++ %{srcroot}/examples/c-api/buildsystem/main.c -I %{srcroot}/products/libllbuild/include -lllbuild -lllbuildBuildSystem -lllbuildCore -lllbuildBasic -lllvmSupport -lllvmDemangle -L %{llbuild-lib-dir} -Werror -Xlinker %{sqlite} %{curses} %{threads} %{dl}
 # RUN: env DYLD_LIBRARY_PATH=%{llbuild-lib-dir} LD_LIBRARY_PATH=%{llbuild-lib-dir} %t.exe %s > %t.out
 # RUN: %{FileCheck} %s --input-file %t.out
 #

--- a/utils/import-llvm/cmake/demangleCMakeLists.txt
+++ b/utils/import-llvm/cmake/demangleCMakeLists.txt
@@ -1,4 +1,4 @@
-add_llbuild_library(LLVMDemangle
+add_llbuild_library(llvmDemangle
     ItaniumDemangle.cpp
     MicrosoftDemangle.cpp
 )

--- a/utils/import-llvm/cmake/supportCMakeLists.txt
+++ b/utils/import-llvm/cmake/supportCMakeLists.txt
@@ -55,7 +55,7 @@ raw_ostream.cpp
 
 
 target_link_libraries(llvmSupport PRIVATE
-  LLVMDemangle
+  llvmDemangle
   Threads::Threads
   ${CMAKE_DL_LIBS})
 


### PR DESCRIPTION
This mirrors the change to `LLVMSupport`. While this is not a robust change, it does make the build more uniform. We should instead be adding inline namespaces and renaming the library as we do in the Swift runtime.