### PR TITLE
Fix CMake warnings in llbuild

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ set(LLBUILD_LIBDIR_SUFFIX "${LIB_SUFFIX}" CACHE STRING "Set default library fold
 if(BUILD_TESTING)
   find_package(Lit)
   find_package(FileCheck)
-  find_package(PythonInterp)
+  find_package(Python3 3.7 COMPONENTS Interpreter)
 endif()
 
 ###

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,8 +18,7 @@ configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/Unit/lit.site.cfg.in
   ${CMAKE_CURRENT_BINARY_DIR}/Unit/lit.site.cfg)
 
-include(FindPython)
-if(Python_Interpreter_FOUND AND LIT_FOUND AND FILECHECK_FOUND)
+if(Python3_Interpreter_FOUND AND LIT_FOUND AND FILECHECK_FOUND)
   set(LIT_ARGS "${LLBUILD_LIT_ARGS}")
   separate_arguments(LIT_ARGS)
   
@@ -29,7 +28,7 @@ if(Python_Interpreter_FOUND AND LIT_FOUND AND FILECHECK_FOUND)
   endif()
 
   set(lit_command
-    ${Python_EXECUTABLE}
+    ${Python3_EXECUTABLE}
     ${LIT_EXECUTABLE}
     ${LIT_ARGS}
     --param build_mode=${build_mode})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,9 +45,6 @@ if(Python3_Interpreter_FOUND AND LIT_FOUND AND FILECHECK_FOUND)
   add_dependencies(test-llbuild ${test_target_dependencies})
 
   # Add a target for running all tests.
-  if(POLICY CMP0037)
-    cmake_policy(SET CMP0037 OLD)
-  endif(POLICY CMP0037)
   add_custom_target(test)
   add_dependencies(test test-llbuild)
   set_target_properties(test PROPERTIES FOLDER "Tests")


### PR DESCRIPTION
The llbuild project was emitting a few warnings from the CMake build. This was because it was relying on deprecated modules and behaviors. These patches fix both.

The `PythonInterp` module is deprecated in favor of `Python`, `Python2`, or `Python3`. Given that `llvm-lit` no longer works with Python versions at least below 3.7, I've gone ahead and updated this to look for Python 3.7 or newer when testing is enabled.

The project was also using the CMP0037 `OLD` behavior to silence the warning about the `test` target name being reserved. As of CMake 3.11 (llbuild requires 3.19 or newer), it is only reserved when using the CMake testing infrastructure, which `llbuild` does not. Now, setting this version to `OLD` results in a warning about the old behavior being deprecated. It isn't needed, so I've removed it.