### PR TITLE
Return ENOSYS for posix_spawn_file_actions_addchdir on older Android versions

### DIFF
--- a/lib/Basic/Subprocess.cpp
+++ b/lib/Basic/Subprocess.cpp
@@ -102,6 +102,9 @@ static int posix_spawn_file_actions_addchdir_polyfill(posix_spawn_file_actions_t
   //  - FreeBSD 13.1 (May 2022)
   //  - Android 14 (October 2023)
   return posix_spawn_file_actions_addchdir_np((posix_spawn_file_actions_t *)file_actions, path);
+#elif defined(__ANDROID__)
+  //  - Android < 14
+  return ENOSYS;
 #else
   // Standardized posix_spawn_file_actions_addchdir version (POSIX.1-2024, June 2024) available in:
   //  - Solaris 11.4 (August 2018)


### PR DESCRIPTION
This fixes the Android build error introduced in https://github.com/swiftlang/swift-llbuild/commit/9087bdf8c7d4c95402d6d811745ca5ff3e149741.

According to https://android.googlesource.com/platform/bionic/+/master/docs/status.md, `posix_spawn_file_actions_addchdir_np` was only added in API level 34. There seems to be no equivalent for earlier versions, so we just return `ENOSYS` for lower API levels (such as API level 29, which the Android SDK is targeting).