### PR TITLE
[6.2] Add support for thread-safe chdir in process spawning

### DIFF
--- a/unittests/Swift/BuildSystemEngineTests.swift
+++ b/unittests/Swift/BuildSystemEngineTests.swift
@@ -22,7 +22,7 @@ import llbuildTestSupport
 import WinSDK
 #endif
 
-#if os(Windows) || os(FreeBSD)
+#if !canImport(Darwin)
 fileprivate let NSEC_PER_SEC = 1000000000
 #endif
 


### PR DESCRIPTION
This is needed as a fallback to support Amazon Linux 2 and OpenBSD.

# Conflicts:
#	unittests/Swift/BuildSystemEngineTests.swift