### PR TITLE
build: ensure that dependencies are found for consumers

### DIFF
--- a/cmake/modules/LLBuildConfig.cmake.in
+++ b/cmake/modules/LLBuildConfig.cmake.in
@@ -1,1 +1,6 @@
+set(THREADS_PREFER_PTHREAD_FLAG FALSE)
+find_package(Threads REQUIRED)
+
+find_package(SQLite3 QUIET)
+
 include(@LLBuild_EXPORTS_FILE@)

--- a/products/libllbuild/include/llbuild/llbuild.h
+++ b/products/libllbuild/include/llbuild/llbuild.h
@@ -30,7 +30,6 @@ LLBUILD_EXPORT int llb_get_api_version(void);
 
 // The BuildSystem component.
 #include "buildsystem.h"
-#endif
 
 // The Database component.
 #include "db.h"
@@ -39,3 +38,5 @@ LLBUILD_EXPORT int llb_get_api_version(void);
 #include "buildvalue.h"
 
 #include "ninja.h"
+
+#endif


### PR DESCRIPTION
LLBuild depends on `Threads` and `SQLite3`. Add the module dependencies into the module configuration so that the consumer does not need to provide them *before* the import of the configuration.