### PR TITLE
build: rename `libllbuild` to the proper `liblibllbuild`

### DIFF
--- a/products/libllbuild/CMakeLists.txt
+++ b/products/libllbuild/CMakeLists.txt
@@ -7,14 +7,13 @@ set(SOURCES
   BuildValue-C-API.cpp
   Ninja-C-API.cpp)
 
-add_llbuild_library(libllbuild
+add_llbuild_library(llbuild
   ${SOURCES}
-  STATIC
-  OUTPUT_NAME llbuild)
+  STATIC)
 
-set_property(TARGET libllbuild PROPERTY MACOSX_RPATH ON)
+set_property(TARGET llbuild PROPERTY MACOSX_RPATH ON)
 
-target_link_libraries(libllbuild PRIVATE
+target_link_libraries(llbuild PRIVATE
   llbuildBuildSystem
   llbuildCore
   llbuildBasic
@@ -23,15 +22,15 @@ target_link_libraries(libllbuild PRIVATE
   SQLite::SQLite3)
 
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)
-    set_target_properties(libllbuild PROPERTIES LINK_FLAGS "/INCREMENTAL:NO")
+    set_target_properties(llbuild PROPERTIES LINK_FLAGS "/INCREMENTAL:NO")
 endif()
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
-  target_link_libraries(libllbuild PRIVATE
+  target_link_libraries(llbuild PRIVATE
     curses)
 endif()
 
-target_include_directories(libllbuild
+target_include_directories(llbuild
   PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
@@ -41,28 +40,28 @@ include_directories(BEFORE
 
 install(DIRECTORY include/
   DESTINATION include
-  COMPONENT libllbuild
+  COMPONENT llbuild
   FILES_MATCHING
   PATTERN "*.h")
 
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/
   DESTINATION include
-  COMPONENT libllbuild
+  COMPONENT llbuild
   FILES_MATCHING
   PATTERN "*.h")
 
-install(TARGETS libllbuild
+install(TARGETS llbuild
   ARCHIVE DESTINATION lib${LLBUILD_LIBDIR_SUFFIX}
   LIBRARY DESTINATION lib${LLBUILD_LIBDIR_SUFFIX}
   RUNTIME DESTINATION bin
-  COMPONENT libllbuild)
-set_property(GLOBAL APPEND PROPERTY LLBuild_EXPORTS libllbuild)
+  COMPONENT llbuild)
+set_property(GLOBAL APPEND PROPERTY LLBuild_EXPORTS llbuild)
 
-add_custom_target(install-libllbuild
-                  DEPENDS libllbuild
-                  COMMENT "Installing libllbuild..."
+add_custom_target(install-llbuild
+                  DEPENDS llbuild
+                  COMMENT "Installing llbuild..."
                   COMMAND "${CMAKE_COMMAND}"
-                          -DCMAKE_INSTALL_COMPONENT=libllbuild
+                          -DCMAKE_INSTALL_COMPONENT=llbuild
                           -P "${CMAKE_BINARY_DIR}/cmake_install.cmake")
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/products/llbuild/CMakeLists.txt
+++ b/products/llbuild/CMakeLists.txt
@@ -1,7 +1,7 @@
-add_executable(llbuild
+add_executable(llbuild-tool
   main.cpp)
 
-target_link_libraries(llbuild PRIVATE
+target_link_libraries(llbuild-tool PRIVATE
   llbuildCommands
   llbuildNinja
   llbuildBuildSystem
@@ -11,10 +11,13 @@ target_link_libraries(llbuild PRIVATE
   SQLite::SQLite3)
 
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)
-    set_target_properties(llbuild PROPERTIES LINK_FLAGS "/INCREMENTAL:NO")
+    set_target_properties(llbuild-tool PROPERTIES LINK_FLAGS "/INCREMENTAL:NO")
 endif()
 
+set_target_properties(llbuild-tool PROPERTIES
+  OUTPUT_NAME llbuild)
+
 if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
-  target_link_libraries(llbuild PRIVATE
+  target_link_libraries(llbuild-tool PRIVATE
     curses)
 endif()

--- a/products/llbuildSwift/CMakeLists.txt
+++ b/products/llbuildSwift/CMakeLists.txt
@@ -24,7 +24,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL Windows)
     "SHELL:-Xcc -D_CRT_NONSTDC_NO_DEPRECATE")
 endif()
 target_link_libraries(llbuildSwift PRIVATE
-    libllbuild)
+    llbuild)
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
   set_target_properties(llbuildSwift PROPERTIES
     # RUNPATH for finding Swift core libraries in the toolchain.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,7 +34,7 @@ if(Python3_Interpreter_FOUND AND LIT_FOUND AND FILECHECK_FOUND)
     --param build_mode=${build_mode})
 
   set(test_target_dependencies
-    llbuild libllbuild swift-build-tool UnitTests adjust-times)
+    llbuild-tool llbuild swift-build-tool UnitTests adjust-times)
 
   add_custom_target(test-llbuild
     COMMAND ${lit_command} ${CMAKE_CURRENT_BINARY_DIR}

--- a/unittests/CAPI/CMakeLists.txt
+++ b/unittests/CAPI/CMakeLists.txt
@@ -10,7 +10,7 @@ add_llbuild_unittest(CAPITests
 target_link_libraries(CAPITests PRIVATE
   llvmSupport
   llbuildBasic
-  libllbuild
+  llbuild
   SQLite::SQLite3)
 
 if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Windows")


### PR DESCRIPTION
Because `llbuild` is the executable, we cannot have another target with the name `llbuild` which is the library target. As such, the library is named `libllbuild`. This changes the output name of the library to `liblibllbuild`. This was being overridden which caused some trouble for builds which attempted to skirt the dependencies. Rename the output to the proper name.