### PR TITLE
Revert "use Win32 file APIs and widePath for file ops to support long filenames"

### DIFF
--- a/lib/Basic/PlatformUtility.cpp
+++ b/lib/Basic/PlatformUtility.cpp
@@ -38,10 +38,9 @@ using namespace llbuild::basic;
 
 bool sys::chdir(const char *fileName) {
 #if defined(_WIN32)
-  llvm::SmallVector<wchar_t, MAX_PATH> wFileName;
-  if (llvm::sys::path::widenPath(fileName, wFileName))
-    return false;
-  return SetCurrentDirectoryW(wFileName.data());
+  llvm::SmallVector<llvm::UTF16, 20> wFileName;
+  llvm::convertUTF8ToUTF16String(fileName, wFileName);
+  return SetCurrentDirectoryW((LPCWSTR)wFileName.data());
 #else
   return ::chdir(fileName) == 0;
 #endif
@@ -64,13 +63,10 @@ time_t filetimeToTime_t(FILETIME ft) {
 
 int sys::lstat(const char *fileName, sys::StatStruct *buf) {
 #if defined(_WIN32)
-  llvm::SmallVector<wchar_t, MAX_PATH> wfilename;
-  if (llvm::sys::path::widenPath(fileName, wfilename)) {
-    errno = EINVAL;
-    return -1;
-  }
+  llvm::SmallVector<llvm::UTF16, 20> wfilename;
+  llvm::convertUTF8ToUTF16String(fileName, wfilename);
   HANDLE h = CreateFileW(
-      /*lpFileName=*/wfilename.data(),
+      /*lpFileName=*/(LPCWSTR)wfilename.data(),
       /*dwDesiredAccess=*/0,
       /*dwShareMode=*/FILE_SHARE_READ,
       /*lpSecurityAttributes=*/NULL,
@@ -127,10 +123,7 @@ int sys::lstat(const char *fileName, sys::StatStruct *buf) {
 
 bool sys::mkdir(const char* fileName) {
 #if defined(_WIN32)
-  llvm::SmallVector<wchar_t, MAX_PATH> wfilename;
-  if (llvm::sys::path::widenPath(fileName, wfilename))
-    return false;
-  return CreateDirectoryW(wfilename.data(), NULL) != 0;
+  return _mkdir(fileName) == 0;
 #else
   return ::mkdir(fileName, S_IRWXU | S_IRWXG |  S_IRWXO) == 0;
 #endif
@@ -171,25 +164,7 @@ int sys::read(int fileHandle, void *destinationBuffer,
 
 int sys::rmdir(const char *path) {
 #if defined(_WIN32)
-  llvm::SmallVector<wchar_t, MAX_PATH> wpath;
-  if (llvm::sys::path::widenPath(path, wpath)) {
-    errno = EINVAL;
-    return -1;
-  }
-  if (RemoveDirectoryW(wpath.data())) {
-    return 0;
-  }
-  int err = GetLastError();
-  if (err == ERROR_FILE_NOT_FOUND || err == ERROR_PATH_NOT_FOUND) {
-    errno = ENOENT;
-  } else if (err == ERROR_ACCESS_DENIED) {
-    errno = EACCES;
-  } else if (err == ERROR_DIR_NOT_EMPTY) {
-    errno = ENOTEMPTY;
-  } else {
-    errno = EINVAL;
-  }
-  return -1;
+  return ::_rmdir(path);
 #else
   return ::rmdir(path);
 #endif
@@ -197,46 +172,7 @@ int sys::rmdir(const char *path) {
 
 int sys::stat(const char *fileName, StatStruct *buf) {
 #if defined(_WIN32)
-  llvm::SmallVector<wchar_t, MAX_PATH> wfilename;
-  if (llvm::sys::path::widenPath(fileName, wfilename)) {
-    errno = EINVAL;
-    return -1;
-  }
-  
-  WIN32_FILE_ATTRIBUTE_DATA fileData;
-  if (!GetFileAttributesExW(wfilename.data(), GetFileExInfoStandard, &fileData)) {
-    int err = GetLastError();
-    if (err == ERROR_FILE_NOT_FOUND || err == ERROR_PATH_NOT_FOUND) {
-      errno = ENOENT;
-    } else if (err == ERROR_ACCESS_DENIED) {
-      errno = EACCES;
-    } else {
-      errno = EINVAL;
-    }
-    return -1;
-  }
-  
-  // Fill the stat structure
-  buf->st_gid = 0;
-  buf->st_atime = filetimeToTime_t(fileData.ftLastAccessTime);
-  buf->st_ctime = filetimeToTime_t(fileData.ftCreationTime);
-  buf->st_dev = 0;
-  buf->st_ino = 0;
-  buf->st_rdev = 0;
-  buf->st_mode = (fileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) ? _S_IFDIR : _S_IFREG;
-  buf->st_mode |= (fileData.dwFileAttributes & FILE_ATTRIBUTE_READONLY) ? _S_IREAD : _S_IREAD | _S_IWRITE;
-  
-  llvm::StringRef extension = llvm::sys::path::extension(llvm::StringRef(fileName));
-  if (extension == ".exe" || extension == ".cmd" || extension == ".bat" || extension == ".com") {
-    buf->st_mode |= _S_IEXEC;
-  }
-  
-  buf->st_mtime = filetimeToTime_t(fileData.ftLastWriteTime);
-  buf->st_nlink = 1;
-  buf->st_size = ((long long)fileData.nFileSizeHigh << 32) | fileData.nFileSizeLow;
-  buf->st_uid = 0;
-  
-  return 0;
+  return ::_stat(fileName, buf);
 #else
   return ::stat(fileName, buf);
 #endif
@@ -245,13 +181,11 @@ int sys::stat(const char *fileName, StatStruct *buf) {
 // Create a symlink named linkPath which contains the string pointsTo
 int sys::symlink(const char *pointsTo, const char *linkPath) {
 #if defined(_WIN32)
-  llvm::SmallVector<wchar_t, MAX_PATH> wPointsTo;
-  if (llvm::sys::path::widenPath(pointsTo, wPointsTo))
-    return -1;
-  llvm::SmallVector<wchar_t, MAX_PATH> wLinkPath;
-  if (llvm::sys::path::widenPath(linkPath, wLinkPath))
-    return -1;
-  DWORD attributes = GetFileAttributesW(wPointsTo.data());
+  llvm::SmallVector<llvm::UTF16, 20> wPointsTo;
+  llvm::convertUTF8ToUTF16String(pointsTo, wPointsTo);
+  llvm::SmallVector<llvm::UTF16, 20> wLinkPath;
+  llvm::convertUTF8ToUTF16String(linkPath, wLinkPath);
+  DWORD attributes = GetFileAttributesW((LPCWSTR)wPointsTo.data());
   DWORD directoryFlag = (attributes != INVALID_FILE_ATTRIBUTES &&
                          attributes & FILE_ATTRIBUTE_DIRECTORY)
                             ? SYMBOLIC_LINK_FLAG_DIRECTORY
@@ -259,7 +193,7 @@ int sys::symlink(const char *pointsTo, const char *linkPath) {
   // Note that CreateSymbolicLinkW takes its arguments in reverse order
   // compared to symlink/_symlink
   return !::CreateSymbolicLinkW(
-      wLinkPath.data(), wPointsTo.data(),
+      (LPCWSTR)wLinkPath.data(), (LPCWSTR)wPointsTo.data(),
       SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE | directoryFlag);
 #else
   return ::symlink(pointsTo, linkPath);
@@ -268,23 +202,7 @@ int sys::symlink(const char *pointsTo, const char *linkPath) {
 
 int sys::unlink(const char *fileName) {
 #if defined(_WIN32)
-  llvm::SmallVector<wchar_t, MAX_PATH> wfilename;
-  if (llvm::sys::path::widenPath(fileName, wfilename)) {
-    errno = EINVAL;
-    return -1;
-  }
-  if (DeleteFileW(wfilename.data())) {
-    return 0;
-  }
-  int err = GetLastError();
-  if (err == ERROR_FILE_NOT_FOUND) {
-    errno = ENOENT;
-  } else if (err == ERROR_ACCESS_DENIED) {
-    errno = EACCES;
-  } else {
-    errno = EINVAL;
-  }
-  return -1;
+  return ::_unlink(fileName);
 #else
   return ::unlink(fileName);
 #endif
@@ -345,15 +263,14 @@ int sys::raiseOpenFileLimit(llbuild_rlim_t limit) {
 sys::MATCH_RESULT sys::filenameMatch(const std::string& pattern,
                                      const std::string& filename) {
 #if defined(_WIN32)
-  llvm::SmallVector<wchar_t, MAX_PATH> wpattern;
-  llvm::SmallVector<wchar_t, MAX_PATH> wfilename;
+  llvm::SmallVector<llvm::UTF16, 20> wpattern;
+  llvm::SmallVector<llvm::UTF16, 20> wfilename;
 
-  if (llvm::sys::path::widenPath(pattern, wpattern) ||
-      llvm::sys::path::widenPath(filename, wfilename))
-    return sys::MATCH_ERROR;
+  llvm::convertUTF8ToUTF16String(pattern, wpattern);
+  llvm::convertUTF8ToUTF16String(filename, wfilename);
 
   bool result =
-      PathMatchSpecW(wfilename.data(), wpattern.data());
+      PathMatchSpecW((LPCWSTR)wfilename.data(), (LPCWSTR)wpattern.data());
   return result ? sys::MATCH : sys::NO_MATCH;
 #else
   int result = fnmatch(pattern.c_str(), filename.c_str(), 0);
@@ -425,17 +342,9 @@ std::string sys::makeTmpDir() {
 #if defined(_WIN32)
   char path[MAX_PATH];
   tmpnam_s(path, MAX_PATH);
-  llvm::SmallVector<wchar_t, MAX_PATH> wPath;
-  if (llvm::sys::path::widenPath(path, wPath))
-    return std::string();
-  if (!CreateDirectoryW(wPath.data(), NULL)) {
-    DWORD error = GetLastError();
-    if (error != ERROR_ALREADY_EXISTS) {
-      fprintf(stderr, "Failed to create temporary directory '%s': error code %lu\n",
-              path, (unsigned long)error);
-      return std::string();
-    }
-  }
+  llvm::SmallVector<llvm::UTF16, 20> wPath;
+  llvm::convertUTF8ToUTF16String(path, wPath);
+  CreateDirectoryW((LPCWSTR)wPath.data(), NULL);
   return std::string(path);
 #else
   if (const char *tmpDir = std::getenv("TMPDIR")) {
@@ -462,10 +371,15 @@ std::string sys::getPathSeparators() {
 
 sys::ModuleTraits<>::Handle sys::OpenLibrary(const char *path) {
 #if defined(_WIN32)
-  llvm::SmallVector<wchar_t, MAX_PATH> wPath;
-  if (llvm::sys::path::widenPath(path, wPath))
-    return nullptr;
-  return LoadLibraryW(wPath.data());
+  int cchLength =
+      MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path, strlen(path),
+                          nullptr, 0);
+  std::u16string buffer(cchLength + 1, 0);
+  MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path, strlen(path),
+                      const_cast<LPWSTR>(reinterpret_cast<LPCWSTR>(buffer.data())),
+                      buffer.size());
+
+  return LoadLibraryW(reinterpret_cast<LPCWSTR>(buffer.data()));
 #else
   return dlopen(path, RTLD_LAZY);
 #endif
@@ -487,3 +401,4 @@ void sys::CloseLibrary(sys::ModuleTraits<>::Handle handle) {
   dlclose(handle);
 #endif
 }
+

--- a/src/llbuild3/LocalExecutor.cpp
+++ b/src/llbuild3/LocalExecutor.cpp
@@ -246,47 +246,27 @@ std::string formatWindowsCommandString(std::vector<std::string> args) {
 
 std::error_code checkExecutable(const std::filesystem::path& path) {
 
-#if defined(_WIN32)
-  llvm::SmallVector<wchar_t, MAX_PATH> wpath;
-  if (llvm::sys::path::widenPath(path.c_str(), wpath)) {
-    return std::make_error_code(std::errc::invalid_argument);
-  }
-  
-  DWORD attributes = GetFileAttributesW(wpath.data());
-  if (attributes == INVALID_FILE_ATTRIBUTES) {
-    DWORD err = GetLastError();
-    if (err == ERROR_FILE_NOT_FOUND || err == ERROR_PATH_NOT_FOUND) {
-      return std::make_error_code(std::errc::no_such_file_or_directory);
-    } else if (err == ERROR_ACCESS_DENIED) {
-      return std::make_error_code(std::errc::permission_denied);
-    } else {
-      return std::error_code(err, std::system_category());
-    }
-  }
-#else
   if (::access(path.c_str(), R_OK | X_OK) == -1) {
     return std::error_code(errno, std::generic_category());
   }
-#endif
 
   // Don't say that directories are executable.
 #if defined(_WIN32)
-  WIN32_FILE_ATTRIBUTE_DATA fileData;
-  if (!GetFileAttributesExW(wpath.data(), GetFileExInfoStandard, &fileData)) {
-    return std::make_error_code(std::errc::permission_denied);
-  }
-  
-  if (fileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
-    return std::make_error_code(std::errc::permission_denied);
+  struct ::_stat buf;
 #else
   struct ::stat buf;
+#endif
+
+#if defined(_WIN32)
+  if (0 != ::_stat(path.c_str(), &buf)) {
+#else
   if (0 != ::stat(path.c_str(), &buf)) {
+#endif
     return std::make_error_code(std::errc::permission_denied);
   }
 
   if (!S_ISREG(buf.st_mode))
     return std::make_error_code(std::errc::permission_denied);
-#endif
 
   return std::error_code();
 }


### PR DESCRIPTION
Reverts swiftlang/swift-llbuild#1004. Possibly the cause of Windows CI failures, will run cross PR testing to check.