### PR TITLE
Remove /INCREMENTAL:NO flag for llbuild-tool and libllbuild targets on Windows

### DIFF
--- a/products/libllbuild/CMakeLists.txt
+++ b/products/libllbuild/CMakeLists.txt
@@ -21,10 +21,6 @@ target_link_libraries(llbuild PRIVATE
   llvmSupport
   SQLite::SQLite3)
 
-if(CMAKE_SYSTEM_NAME STREQUAL Windows)
-    set_target_properties(llbuild PROPERTIES LINK_FLAGS "/INCREMENTAL:NO")
-endif()
-
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
   target_link_libraries(llbuild PRIVATE
     curses)

--- a/products/llbuild/CMakeLists.txt
+++ b/products/llbuild/CMakeLists.txt
@@ -10,10 +10,6 @@ target_link_libraries(llbuild-tool PRIVATE
   llvmSupport
   SQLite::SQLite3)
 
-if(CMAKE_SYSTEM_NAME STREQUAL Windows)
-    set_target_properties(llbuild-tool PROPERTIES LINK_FLAGS "/INCREMENTAL:NO")
-endif()
-
 set_target_properties(llbuild-tool PROPERTIES
   OUTPUT_NAME llbuild)
 


### PR DESCRIPTION
These were originally added 6 years ago in #475 to "Disable incremental linking so llbuild.ilk's don't conflict" because at the time the command line tool and library targets were given the same OUTPUT_NAME, which conflicted. In #1005 these targets were given distinct names, so the workaround should no longer be necessary.

This helps unblock swiftlang/swift-build#757 because this flag is currently added without regard for the specific compiler driver in use, so the flag might not work based on whether clang-cl.exe or cl.exe vs clang.exe (where it would require a -Xlinker prefix), is used.