### PR TITLE
Add Chromium Trace export to llbuild-analyze

### DIFF
--- a/products/llbuild-analyze/Package.swift
+++ b/products/llbuild-analyze/Package.swift
@@ -23,7 +23,16 @@ let package = Package(
     targets: [
         .target(
             name: "llbuildAnalyzeTool",
-            dependencies: ["SwiftToolsSupport-auto", "llbuildAnalysis", "ArgumentParser"],
-            path: "Sources"),
+            dependencies: ["SwiftToolsSupport-auto", "llbuildAnalysis", "llbuildAnalyzeSupport", "ArgumentParser"],
+            path: "Sources",
+            exclude: ["llbuildAnalyzeSupport"]),
+        .target(
+            name: "llbuildAnalyzeSupport",
+            dependencies: ["llbuildAnalysis", "llbuildSwift"],
+            path: "Sources/llbuildAnalyzeSupport"),
+        .testTarget(
+            name: "ChromiumTraceSerializationTests",
+            dependencies: ["llbuildAnalyzeSupport"],
+            path: "Tests/ChromiumTraceSerializationTests"),
     ]
 )

--- a/products/llbuild-analyze/Sources/CriticalPathTool.swift
+++ b/products/llbuild-analyze/Sources/CriticalPathTool.swift
@@ -8,6 +8,7 @@
 
 import TSCBasic
 import llbuildAnalysis
+import llbuildAnalyzeSupport
 import llbuildSwift
 import ArgumentParser
 
@@ -19,7 +20,20 @@ struct CriticalPathTool: ParsableCommand {
     static var configuration = CommandConfiguration(commandName: "critical-path", shouldDisplay: true)
     
     enum OutputFormat: String, ExpressibleByArgument {
-        case json, graphviz
+        case json, graphviz, chromiumTrace = "chromium-trace"
+
+        init?(argument: String) {
+            switch argument {
+            case "json":
+                self = .json
+            case "graphviz":
+                self = .graphviz
+            case "chromium-trace", "chromiumTrace":
+                self = .chromiumTrace
+            default:
+                return nil
+            }
+        }
     }
 
     enum GraphvizDisplay: String, ExpressibleByArgument {
@@ -62,6 +76,8 @@ struct CriticalPathTool: ParsableCommand {
                 data = try json(path, allKeyResults: allKeysWithResult, buildKeyLookup: solver.keyLookup)
             case .graphviz:
                 data = graphViz(path, buildKeyLookup: solver.keyLookup)
+            case .chromiumTrace:
+                data = try chromiumTrace(path, allKeyResults: allKeysWithResult)
             }
             try verifyOutputPath()
             FileManager.default.createFile(atPath: outputPath.pathString, contents: data)

--- a/products/llbuild-analyze/Sources/llbuildAnalyzeSupport/PathChromiumTraceSerialization.swift
+++ b/products/llbuild-analyze/Sources/llbuildAnalyzeSupport/PathChromiumTraceSerialization.swift
@@ -1,0 +1,113 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+import llbuildAnalysis
+import llbuildSwift
+
+import struct Foundation.Data
+import class Foundation.JSONEncoder
+
+// MARK: - Chromium Trace Serialization
+
+private let microsecondsPerSecond = 1_000_000.0
+
+struct ChromiumTraceEvent: Encodable, Equatable {
+    enum CodingKeys: String, CodingKey {
+        case name, cat, ph, ts, dur, pid, tid, args
+    }
+
+    struct Arguments: Encodable, Equatable {
+        let buildKeyKind: String
+        let buildKey: String
+        let valueKind: String
+        let durationSeconds: Double
+        let onCriticalPath: Bool
+        let dependencies: [String]
+    }
+
+    let name: String
+    let cat: String
+    let ph: String
+    let ts: UInt64
+    let dur: UInt64
+    let pid: Int
+    let tid: Int
+    let args: Arguments
+}
+
+struct ChromiumTraceFile: Encodable, Equatable {
+    let traceEvents: [ChromiumTraceEvent]
+}
+
+public func chromiumTrace(_ path: CriticalBuildPath, allKeyResults: BuildDBKeysWithResult) throws
+    -> Data
+{
+    let criticalPathKeys = Set(path.map { $0.key })
+    let events = allKeyResults.map { element in
+        chromiumTraceEvent(for: element, isOnCriticalPath: criticalPathKeys.contains(element.key))
+    }
+
+    let encoder = JSONEncoder()
+    if #available(OSX 10.13, *) {
+        encoder.outputFormatting = [.sortedKeys]
+    }
+    return try encoder.encode(ChromiumTraceFile(traceEvents: events))
+}
+
+func chromiumTraceEvent(
+    for element: BuildDBKeysWithResult.Element,
+    isOnCriticalPath: Bool
+) -> ChromiumTraceEvent {
+    return chromiumTraceEvent(
+        name: element.key.description,
+        buildKeyKind: element.key.kind.description,
+        buildKey: element.key.key,
+        valueKind: element.result.value.kind.description,
+        start: element.result.start,
+        duration: element.result.duration,
+        isOnCriticalPath: isOnCriticalPath,
+        dependencies: element.result.dependencies.map { $0.description }
+    )
+}
+
+func chromiumTraceEvent(
+    name: String,
+    buildKeyKind: String,
+    buildKey: String,
+    valueKind: String,
+    start: Double,
+    duration: Double,
+    isOnCriticalPath: Bool,
+    dependencies: [String]
+) -> ChromiumTraceEvent {
+    return ChromiumTraceEvent(
+        name: name,
+        cat: isOnCriticalPath ? "critical-path" : "build",
+        ph: "X",
+        ts: timestampInMicroseconds(start),
+        dur: durationInMicroseconds(duration),
+        pid: 0,
+        tid: 0,
+        args: ChromiumTraceEvent.Arguments(
+            buildKeyKind: buildKeyKind,
+            buildKey: buildKey,
+            valueKind: valueKind,
+            durationSeconds: duration,
+            onCriticalPath: isOnCriticalPath,
+            dependencies: dependencies
+        )
+    )
+}
+
+private func timestampInMicroseconds(_ seconds: Double) -> UInt64 {
+    return UInt64(max(0, seconds * microsecondsPerSecond))
+}
+
+private func durationInMicroseconds(_ seconds: Double) -> UInt64 {
+    return UInt64(max(0, seconds * microsecondsPerSecond))
+}

--- a/products/llbuild-analyze/Tests/ChromiumTraceSerializationTests/ChromiumTraceSerializationTests.swift
+++ b/products/llbuild-analyze/Tests/ChromiumTraceSerializationTests/ChromiumTraceSerializationTests.swift
@@ -1,0 +1,61 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+import XCTest
+import class Foundation.JSONEncoder
+import class Foundation.JSONSerialization
+
+@testable import llbuildAnalyzeSupport
+
+final class ChromiumTraceSerializationTests: XCTestCase {
+    func testChromiumTraceFileWrapsEvents() throws {
+        let event = chromiumTraceEvent(
+            name: "<BuildKey.Command name=compile-main>",
+            buildKeyKind: "command",
+            buildKey: "compile-main",
+            valueKind: "skipped-command",
+            start: 1.25,
+            duration: 1.5,
+            isOnCriticalPath: true,
+            dependencies: ["<BuildKey.Node name=main.swift>"]
+        )
+        let data = try JSONEncoder().encode(ChromiumTraceFile(traceEvents: [event]))
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        let events = try XCTUnwrap(json["traceEvents"] as? [[String: Any]])
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?["name"] as? String, "<BuildKey.Command name=compile-main>")
+    }
+
+    func testChromiumTraceEventUsesCompleteEventFormat() {
+        let event = chromiumTraceEvent(
+            name: "<BuildKey.Command name=compile-main>",
+            buildKeyKind: "command",
+            buildKey: "compile-main",
+            valueKind: "skipped-command",
+            start: 1.25,
+            duration: 1.5,
+            isOnCriticalPath: true,
+            dependencies: ["<BuildKey.Node name=main.swift>"]
+        )
+
+        XCTAssertEqual(event.name, "<BuildKey.Command name=compile-main>")
+        XCTAssertEqual(event.cat, "critical-path")
+        XCTAssertEqual(event.ph, "X")
+        XCTAssertEqual(event.ts, 1_250_000)
+        XCTAssertEqual(event.dur, 1_500_000)
+        XCTAssertEqual(event.pid, 0)
+        XCTAssertEqual(event.tid, 0)
+        XCTAssertEqual(event.args.buildKeyKind, "command")
+        XCTAssertEqual(event.args.buildKey, "compile-main")
+        XCTAssertEqual(event.args.valueKind, "skipped-command")
+        XCTAssertEqual(event.args.durationSeconds, 1.5)
+        XCTAssertEqual(event.args.onCriticalPath, true)
+        XCTAssertEqual(event.args.dependencies, ["<BuildKey.Node name=main.swift>"])
+    }
+}


### PR DESCRIPTION
## Summary

Add Chromium Trace export support to `llbuild-analyze critical-path`.

The new `chromium-trace` format exports build timing, dependencies, and
critical-path information as Chrome Trace-compatible JSON.

## Verification

- `swift test --package-path products/llbuild-analyze --disable-sandbox`
- `swift build --package-path products/llbuild-analyze --disable-sandbox`
- Validated output from a real `build.db` with `jq`
- `git diff --check`

Fixes #781