### PR TITLE
CMake: Update SQLite3 references

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,9 @@ set(THREADS_PREFER_PTHREAD_FLAG FALSE)
 find_package(Threads REQUIRED)
 
 find_package(SQLite3 QUIET)
-if(NOT SQLite3_FOUND)
+if(SQLite3_FOUND AND NOT TARGET SQLite3::SQLite3)
+  add_library(SQLite3::SQLite3 ALIAS SQLite::SQLite3)
+elseif(NOT SQLite3_FOUND)
   include(FetchContent)
 
   message("-- Vendoring SQLite3")
@@ -61,7 +63,7 @@ if(NOT SQLite3_FOUND)
 
   FetchContent_MakeAvailable(SQLite)
 
-  add_library(SQLite::SQLite3 ALIAS SQLite3)
+  add_library(SQLite3::SQLite3 ALIAS SQLite3)
   set_property(GLOBAL APPEND PROPERTY LLBuild_EXPORTS SQLite3)
 endif()
 
@@ -146,10 +148,10 @@ if (XCODE)
   set(CMAKE_XCODE_ATTRIBUTE_GCC_ENABLE_CPP_RTTI "NO")
 
   # Disable exceptions.
-  set(CMAKE_XCODE_ATTRIBUTE_GCC_ENABLE_CPP_EXCEPTIONS "NO") 
+  set(CMAKE_XCODE_ATTRIBUTE_GCC_ENABLE_CPP_EXCEPTIONS "NO")
 
   # Disable headermaps.
-  set(CMAKE_XCODE_ATTRIBUTE_USE_HEADERMAP "NO") 
+  set(CMAKE_XCODE_ATTRIBUTE_USE_HEADERMAP "NO")
 elseif(MSVC)
   add_compile_options(
     # Disable unknown pragma warnings (e.g. for #pragma mark).

--- a/cmake/modules/LLBuildConfig.cmake.in
+++ b/cmake/modules/LLBuildConfig.cmake.in
@@ -3,4 +3,8 @@ find_package(Threads REQUIRED)
 
 find_package(SQLite3 QUIET)
 
+if(SQLite3_FOUND AND NOT TARGET SQLite3::SQLite3)
+  add_library(SQLite3::SQLite3 ALIAS SQLite::SQLite3)
+endif()
+
 include(@LLBuild_EXPORTS_FILE@)

--- a/lib/Core/CMakeLists.txt
+++ b/lib/Core/CMakeLists.txt
@@ -10,6 +10,6 @@ add_llbuild_library(llbuildCore STATIC
 target_link_libraries(llbuildCore PRIVATE
   llbuildBasic
   llvmSupport
-  SQLite::SQLite3)
+  SQLite3::SQLite3)
 
 set_property(GLOBAL APPEND PROPERTY LLBuild_EXPORTS llbuildCore)

--- a/perftests/Xcode/PerfTests/CMakeLists.txt
+++ b/perftests/Xcode/PerfTests/CMakeLists.txt
@@ -34,7 +34,7 @@ target_link_libraries(XcodePerfTests PRIVATE
   llbuildBuildSystem
   llbuildCommands
   curses
-  SQLite::SQLite3
+  SQLite3::SQLite3
   "${MACOSX_SDK_PATH}/System/Library/Frameworks/Foundation.framework"
   "${MACOSX_PLATFORM_PATH}/Developer/Library/Frameworks/XCTest.framework"
   )
@@ -42,7 +42,7 @@ target_link_libraries(XcodePerfTests PRIVATE
 # Run a custom command to fixup CMake's broken bundle CFBundleExecutable.
 #
 # http://www.cmake.org/Bug/view.php?id=15485
-# 
+#
 # It seems this is no longer an issue in Xcode 11.4/CMake 3.16.3, but leaving this
 # workaround in place for good measure
 get_target_property(xcode_perf_tests_output_directory XcodePerfTests LIBRARY_OUTPUT_DIRECTORY)

--- a/products/libllbuild/CMakeLists.txt
+++ b/products/libllbuild/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(SOURCES 
+set(SOURCES
   BuildSystem-C-API.cpp
   C-API.cpp
   Core-C-API.cpp
@@ -19,7 +19,7 @@ target_link_libraries(llbuild PRIVATE
   llbuildBasic
   llbuildNinja
   llvmSupport
-  SQLite::SQLite3)
+  SQLite3::SQLite3)
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
   target_link_libraries(llbuild PRIVATE
@@ -74,7 +74,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     llbuildBasic
     llbuildNinja
     llvmSupport
-    SQLite::SQLite3
+    SQLite3::SQLite3
     curses)
 
   # Manually set up the remaining framework structure.

--- a/products/llbuild/CMakeLists.txt
+++ b/products/llbuild/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(llbuild-tool PRIVATE
   llbuildCore
   llbuildBasic
   llvmSupport
-  SQLite::SQLite3)
+  SQLite3::SQLite3)
 
 set_target_properties(llbuild-tool PROPERTIES
   OUTPUT_NAME llbuild)

--- a/products/llbuildSwift/CMakeLists.txt
+++ b/products/llbuildSwift/CMakeLists.txt
@@ -42,7 +42,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
   endif()
 else()
   target_link_libraries(llbuildSwift PRIVATE
-    SQLite::SQLite3)
+    SQLite3::SQLite3)
   if(dispatch_FOUND)
     target_link_libraries(llbuildSwift PRIVATE
       swiftDispatch)

--- a/products/swift-build-tool/CMakeLists.txt
+++ b/products/swift-build-tool/CMakeLists.txt
@@ -6,7 +6,7 @@ target_link_libraries(swift-build-tool PRIVATE
   llbuildCore
   llbuildBasic
   llvmSupport
-  SQLite::SQLite3)
+  SQLite3::SQLite3)
 
 if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
   target_link_libraries(swift-build-tool PRIVATE

--- a/unittests/BuildSystem/CMakeLists.txt
+++ b/unittests/BuildSystem/CMakeLists.txt
@@ -12,7 +12,7 @@ target_link_libraries(BuildSystemTests PRIVATE
   llbuildCore
   llbuildBasic
   llvmSupport
-  SQLite::SQLite3)
+  SQLite3::SQLite3)
 
 if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
   target_link_libraries(BuildSystemTests PRIVATE

--- a/unittests/CAPI/CMakeLists.txt
+++ b/unittests/CAPI/CMakeLists.txt
@@ -11,7 +11,7 @@ target_link_libraries(CAPITests PRIVATE
   llvmSupport
   llbuildBasic
   llbuild
-  SQLite::SQLite3)
+  SQLite3::SQLite3)
 
 if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
   target_link_libraries(CAPITests PRIVATE

--- a/unittests/Core/CMakeLists.txt
+++ b/unittests/Core/CMakeLists.txt
@@ -11,7 +11,7 @@ target_link_libraries(CoreTests PRIVATE
   llbuildCore
   llbuildBasic
   llvmSupport
-  SQLite::SQLite3)
+  SQLite3::SQLite3)
 
 if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
   target_link_libraries(CoreTests PRIVATE


### PR DESCRIPTION
The `SQLite::SQlite3` was deprecated in CMake 4.3, resulting in a warning every time it's referenced. The new name is `SQLite3::SQLite3`.

Going through updating the references and removing extra trailing whitespaces while I go.