### PR TITLE
[ninja] Make sure inputs are expanded to commands as they were written

### DIFF
--- a/include/llbuild/Ninja/Manifest.h
+++ b/include/llbuild/Ninja/Manifest.h
@@ -106,6 +106,35 @@ public:
   const std::string& getScreenPath() const { return screenPath; }
 };
 
+/// Captures information about a node appearing in a command.
+///
+/// Nodes are uniqued across commands but how they appear in a command (relative
+/// or absolute path) is important for variable expansion; \c NodeInCommand
+/// preserves such info.
+class NodeInCommand {
+  Node* node;
+  /// This only contains a string if it is different than
+  /// \c node->getScreenPath(), otherwise it is empty.
+  std::string asWritten;
+
+public:
+  NodeInCommand(Node* node, StringRef asWritten) : node(node) {
+    if (node->getScreenPath() != asWritten) {
+      this->asWritten = asWritten;
+    }
+  }
+
+  Node* getNode() const { return node; }
+
+  const std::string& getScreenPath() const {
+    return (asWritten.empty()) ? node->getScreenPath() : asWritten;
+  }
+
+  const std::string& getCanonicalPath() const {
+    return node->getCanonicalPath();
+  }
+};
+
 /// A pool represents a generic bucket for organizing commands.
 class Pool {
   /// The name of the pool.
@@ -157,7 +186,7 @@ private:
   /// implicit and order-only inputs (which are determined by their position in
   /// the array and the \see numExplicitInputs and \see numImplicitInputs
   /// variables).
-  std::vector<Node*> inputs;
+  std::vector<NodeInCommand> inputs;
 
   /// The number of explicit inputs, at the start of the \see inputs array.
   unsigned numExplicitInputs;
@@ -193,7 +222,7 @@ public:
   // copying, but requires SmallVectorImpl to take a move constructor.
   explicit Command(class Rule* rule,
                    ArrayRef<Node*> outputs,
-                   ArrayRef<Node*> inputs,
+                   ArrayRef<NodeInCommand> inputs,
                    unsigned numExplicitInputs,
                    unsigned numImplicitInputs,
                    unsigned numExplicitOutputs)
@@ -221,26 +250,28 @@ public:
     return llvm::makeArrayRef(outputs).take_back(getNumImplicitOutputs());
   }
 
-  const std::vector<Node*>& getInputs() const { return inputs; }
+  const std::vector<NodeInCommand>& getInputs() const {
+    return inputs;
+  }
 
-  const std::vector<Node*>::const_iterator explicitInputs_begin() const {
+  const std::vector<NodeInCommand>::const_iterator explicitInputs_begin() const {
     return inputs.begin();
   }
-  const std::vector<Node*>::const_iterator explicitInputs_end() const {
+  const std::vector<NodeInCommand>::const_iterator explicitInputs_end() const {
     return explicitInputs_begin() + getNumExplicitInputs();
   }
 
-  const std::vector<Node*>::const_iterator implicitInputs_begin() const {
+  const std::vector<NodeInCommand>::const_iterator implicitInputs_begin() const {
     return explicitInputs_end();
   }
-  const std::vector<Node*>::const_iterator implicitInputs_end() const {
+  const std::vector<NodeInCommand>::const_iterator implicitInputs_end() const {
     return implicitInputs_begin() + getNumImplicitInputs();
   }
 
-  const std::vector<Node*>::const_iterator orderOnlyInputs_begin() const {
+  const std::vector<NodeInCommand>::const_iterator orderOnlyInputs_begin() const {
     return implicitInputs_end();
   }
-  const std::vector<Node*>::const_iterator orderOnlyInputs_end() const {
+  const std::vector<NodeInCommand>::const_iterator orderOnlyInputs_end() const {
     return inputs.end();
   }
 

--- a/lib/Commands/NinjaBuildCommand.cpp
+++ b/lib/Commands/NinjaBuildCommand.cpp
@@ -998,7 +998,7 @@ buildCommand(BuildContext& context, ninja::Command* command) {
         if (value.isMissingInput()) {
           hasMissingInput = true;
 
-          context.reportMissingInput(command->getInputs()[inputID]);
+          context.reportMissingInput(command->getInputs()[inputID].getNode());
         }
       } else {
         // Otherwise, track the information used to determine if we can just
@@ -1040,26 +1040,26 @@ buildCommand(BuildContext& context, ninja::Command* command) {
       unsigned id = 0;
       for (auto it = command->explicitInputs_begin(),
              ie = command->explicitInputs_end(); it != ie; ++it, ++id) {
-        if (!context.strict && isPhony && isImmediatelyCyclicInput(*it))
+        if (!context.strict && isPhony && isImmediatelyCyclicInput(it->getNode()))
           continue;
 
-        ti.request((*it)->getCanonicalPath(), id);
+        ti.request(it->getCanonicalPath(), id);
       }
       for (auto it = command->implicitInputs_begin(),
              ie = command->implicitInputs_end(); it != ie; ++it, ++id) {
-        if (!context.strict && isPhony && isImmediatelyCyclicInput(*it))
+        if (!context.strict && isPhony && isImmediatelyCyclicInput(it->getNode()))
           continue;
 
-        ti.request((*it)->getCanonicalPath(), id);
+        ti.request(it->getCanonicalPath(), id);
       }
 
       // Request all of the order-only inputs.
       for (auto it = command->orderOnlyInputs_begin(),
              ie = command->orderOnlyInputs_end(); it != ie; ++it) {
-        if (!context.strict && isPhony && isImmediatelyCyclicInput(*it))
+        if (!context.strict && isPhony && isImmediatelyCyclicInput(it->getNode()))
           continue;
 
-        ti.mustFollow((*it)->getCanonicalPath());
+        ti.mustFollow(it->getCanonicalPath());
       }
     }
 
@@ -2266,8 +2266,8 @@ int commands::executeNinjaBuildCommand(std::vector<std::string> args) {
 
         // Collect all of the input nodes.
         for (const auto& command: context.manifest->getCommands()) {
-          for (const auto* input: command->getInputs()) {
-            inputNodes.emplace(input);
+          for (const auto& input: command->getInputs()) {
+            inputNodes.emplace(input.getNode());
           }
         }
 

--- a/lib/Commands/NinjaCommand.cpp
+++ b/lib/Commands/NinjaCommand.cpp
@@ -558,7 +558,7 @@ static void dumpNinjaManifestText(StringRef file, ninja::Manifest* manifest) {
       } else if (count == command->getNumExplicitInputs()) {
         std::cout << "| ";
       }
-      std::cout << "\"" << util::escapedString(node->getScreenPath()) << "\"";
+      std::cout << "\"" << util::escapedString(node.getScreenPath()) << "\"";
       ++count;
     }
     std::cout << "\n";
@@ -726,7 +726,7 @@ static void dumpNinjaManifestJSON(StringRef file, ninja::Manifest* manifest) {
     for (auto it = command->explicitInputs_begin(),
            ie = command->explicitInputs_end(); it != ie; ++it) {
       if (it != command->explicitInputs_begin()) std::cout << ", ";
-      std::cout << "\"" << escapeForJSON((*it)->getScreenPath()) << "\"";
+      std::cout << "\"" << escapeForJSON(it->getScreenPath()) << "\"";
     }
     std::cout << "],\n";
     if (command->getNumImplicitInputs()) {
@@ -734,7 +734,7 @@ static void dumpNinjaManifestJSON(StringRef file, ninja::Manifest* manifest) {
       for (auto it = command->implicitInputs_begin(),
              ie = command->implicitInputs_end(); it != ie; ++it) {
         if (it != command->implicitInputs_begin()) std::cout << ", ";
-        std::cout << "\"" << escapeForJSON((*it)->getScreenPath()) << "\"";
+        std::cout << "\"" << escapeForJSON(it->getScreenPath()) << "\"";
       }
       std::cout << "],\n";
     }
@@ -743,7 +743,7 @@ static void dumpNinjaManifestJSON(StringRef file, ninja::Manifest* manifest) {
       for (auto it = command->orderOnlyInputs_begin(),
              ie = command->orderOnlyInputs_end(); it != ie; ++it) {
         if (it != command->orderOnlyInputs_begin()) std::cout << ", ";
-        std::cout << "\"" << escapeForJSON((*it)->getScreenPath()) << "\"";
+        std::cout << "\"" << escapeForJSON(it->getScreenPath()) << "\"";
       }
       std::cout << "],\n";
     }

--- a/lib/Ninja/ManifestLoader.cpp
+++ b/lib/Ninja/ManifestLoader.cpp
@@ -331,7 +331,7 @@ public:
 
     // Resolve all of the inputs and outputs.
     SmallVector<Node*, 8> outputs;
-    SmallVector<Node*, 8> inputs;
+    SmallVector<NodeInCommand, 8> inputs;
     for (const auto& token: outputTokens) {
       // Evaluate the token string.
       SmallString<256> path;
@@ -348,7 +348,8 @@ public:
       if (path.empty()) {
         error("empty input path", token);
       }
-      inputs.push_back(manifest->findOrCreateNode(workingDirectory, path));
+      Node *node = manifest->findOrCreateNode(workingDirectory, path);
+      inputs.push_back(NodeInCommand(node, path));
     }
 
     Command* decl = new (manifest->getAllocator())
@@ -400,7 +401,7 @@ public:
       for (unsigned i = 0, ie = decl->getNumExplicitInputs(); i != ie; ++i) {
         if (i != 0)
           result << separator;
-        auto& path = decl->getInputs()[i]->getScreenPath();
+        auto& path = decl->getInputs()[i].getScreenPath();
         result << (context->shellEscapeInAndOut ? basic::shellEscaped(path)
                                                 : path);
       }

--- a/products/libllbuild/Ninja-C-API.cpp
+++ b/products/libllbuild/Ninja-C-API.cpp
@@ -161,6 +161,19 @@ private:
     return copyRefs(llvm::makeArrayRef(&*begin, &*end));
   }
 
+  ArrayRef<llb_string_ref_t> copyRefs(ArrayRef<NodeInCommand> nodes) {
+    return copyTransformed(nodes, [](auto &node) -> llb_string_ref_t {
+      auto &path = node.getScreenPath();
+      return { path.size(), path.data() };
+    });
+  }
+
+  ArrayRef<llb_string_ref_t> copyRefs(
+      const std::vector<NodeInCommand>::const_iterator &begin,
+      const std::vector<NodeInCommand>::const_iterator &end) {
+    return copyRefs(llvm::makeArrayRef(&*begin, &*end));
+  }
+
   ArrayRef<llb_ninja_variable_t> copyRefs(
       const llvm::StringMap<std::string> &variables) {
     return copyTransformed(variables, [&](auto &var) -> llb_ninja_variable_t {

--- a/unittests/Swift/SwiftNinjaTests.swift
+++ b/unittests/Swift/SwiftNinjaTests.swift
@@ -60,6 +60,62 @@ class SwiftNinjaTests: XCTestCase {
     ])
   }
 
+  func testSameInputRelativeAndAbsolutePath() throws {
+    // Two build statements reference the same input file, one using a path
+    // relative to the working directory and the other using the absolute
+    // path. Both nodes must be deduplicated to the same underlying Node, but
+    // each command's $in expansion should reflect the path as written in
+    // that command, not the (possibly different) path used by whichever
+    // command first created the node.
+    let ruleFile = makeTemporaryFile("""
+            rule CMD
+                command = ls $in\n
+            """)
+    let workingDirectory = try URL(fileURLWithPath: ruleFile)
+      .deletingLastPathComponent().withUnsafeFileSystemRepresentation { try XCTUnwrap($0.map(String.init(cString:))) }
+    let absoluteInputPath = "\(workingDirectory)/same-input.txt"
+    // Ninja treats ':' as a path-token delimiter (it separates "output:
+    // rule inputs"), so a Windows drive-letter colon must be escaped as
+    // "$:" when embedded in the manifest source. The escape is undone by
+    // the manifest evaluator, so the expected `$in` expansion below uses
+    // the unescaped path.
+    let escapedAbsoluteInputPath = absoluteInputPath.replacingOccurrences(of: ":", with: "$:")
+    let manifestFile = makeTemporaryFile("""
+            include \(URL(fileURLWithPath: ruleFile).lastPathComponent)
+            build out1: CMD same-input.txt
+            build out2: CMD \(escapedAbsoluteInputPath)\n
+            """)
+
+    let manifest = try NinjaManifest(path: manifestFile, workingDirectory: workingDirectory)
+
+    let expectedRule = NinjaRule(name: "CMD", variables: ["command": "ls $in"])
+    XCTAssertEqual(manifest.rules["CMD"], expectedRule)
+    XCTAssertEqual(manifest.statements, [
+      NinjaBuildStatement(
+        rule: expectedRule,
+        command: "ls same-input.txt",
+        description: "",
+        explicitInputs: ["same-input.txt"],
+        implicitInputs: [],
+        orderOnlyInputs: [],
+        outputs: ["out1"],
+        variables: [:],
+        generator: false,
+        restat: false),
+      NinjaBuildStatement(
+        rule: expectedRule,
+        command: "ls \(absoluteInputPath)",
+        description: "",
+        explicitInputs: [absoluteInputPath],
+        implicitInputs: [],
+        orderOnlyInputs: [],
+        outputs: ["out2"],
+        variables: [:],
+        generator: false,
+        restat: false),
+    ])
+  }
+
   func testMissingRule() throws {
     let manifestFile = makeTemporaryFile("""
             build output: CMD input\n


### PR DESCRIPTION
Two build statements may reference the same input file, one using a path relative to the working directory and the other using the absolute path. Both nodes must be deduplicated to the same underlying `Node`, but each command's `$in` expansion should reflect the path as written in that command, not the (possibly different) path used by whichever command first created the node.