### PR TITLE
[Core] Fix reading past the end of the buffer in MakefileDepsParser

### DIFF
--- a/lib/Core/MakefileDepsParser.cpp
+++ b/lib/Core/MakefileDepsParser.cpp
@@ -99,8 +99,17 @@ static void lexWord(const char*& cur, const char* end,
 
     // Check if this is an escape sequence.
     if (c == '\\') {
-      // If this is a line continuation, it ends the word.
-      if (cur + 1 != end && cur[1] == '\n')
+      // A backslash at the very end of the input has nothing to escape, so it
+      // ends the word. Without this check the escaped character would be read
+      // from one past the end of the buffer, and the cursor would be advanced
+      // past `end`.
+      if (cur + 1 == end)
+        break;
+
+      // If this is a line continuation, it ends the word. Continuations are
+      // recognized with both '\n' and '\r\n' line endings, matching the
+      // endings skipNonNewlineWhitespace() honors.
+      if (cur[1] == '\n' || (cur + 2 < end && cur[1] == '\r' && cur[2] == '\n'))
         break;
 
       // Otherwise, skip the escaped character.

--- a/unittests/Core/MakefileDepsParserTest.cpp
+++ b/unittests/Core/MakefileDepsParserTest.cpp
@@ -120,6 +120,26 @@ TEST(MakefileDepsParserTest, basic) {
   EXPECT_EQ(RuleRecord("out", { "in1" }),
             actions.records[0]);
 
+  // Check a line continuation which immediately follows a word, with both
+  // kinds of line ending. Both must produce the same rule.
+  input = "out: in1\\\n  in2\n";
+  actions.errors.clear();
+  actions.records.clear();
+  MakefileDepsParser(StringRef(input), actions, false).parse();
+  EXPECT_EQ(0U, actions.errors.size());
+  EXPECT_EQ(1U, actions.records.size());
+  EXPECT_EQ(RuleRecord("out", { "in1", "in2" }),
+            actions.records[0]);
+
+  input = "out: in1\\\r\n  in2\n";
+  actions.errors.clear();
+  actions.records.clear();
+  MakefileDepsParser(StringRef(input), actions, false).parse();
+  EXPECT_EQ(0U, actions.errors.size());
+  EXPECT_EQ(1U, actions.records.size());
+  EXPECT_EQ(RuleRecord("out", { "in1", "in2" }),
+            actions.records[0]);
+
   // Check error case if leading garbage.
   actions.errors.clear();
   actions.records.clear();
@@ -153,6 +173,33 @@ TEST(MakefileDepsParserTest, basic) {
             ErrorRecord("unexpected character in prerequisites", 4U));
   EXPECT_EQ(1U, actions.records.size());
   EXPECT_EQ(RuleRecord("a", { "b" }),
+            actions.records[0]);
+
+  // Check a truncated input which ends in a backslash. The backslash has
+  // nothing to escape, so it is reported like any other stray character
+  // instead of consuming the byte past the end of the input.
+  actions.errors.clear();
+  actions.records.clear();
+  input = "a: b\\";
+  MakefileDepsParser(StringRef(input), actions, false).parse();
+  EXPECT_EQ(1U, actions.errors.size());
+  EXPECT_EQ(actions.errors[0],
+            ErrorRecord("unexpected character in prerequisites", 4U));
+  EXPECT_EQ(1U, actions.records.size());
+  EXPECT_EQ(RuleRecord("a", { "b" }),
+            actions.records[0]);
+
+  // Check a truncated input which ends in a backslash while lexing the rule
+  // name.
+  actions.errors.clear();
+  actions.records.clear();
+  input = "a\\";
+  MakefileDepsParser(StringRef(input), actions, false).parse();
+  EXPECT_EQ(1U, actions.errors.size());
+  EXPECT_EQ(actions.errors[0],
+            ErrorRecord("missing ':' following rule", 1U));
+  EXPECT_EQ(1U, actions.records.size());
+  EXPECT_EQ(RuleRecord("a", {}),
             actions.records[0]);
 
   // Check that we can parse filenames with special characters.


### PR DESCRIPTION
`lexWord()` in `lib/Core/MakefileDepsParser.cpp` treats a backslash as the start of an escape sequence unless the next byte is a newline. When the backslash is the last byte of the input that check at line 103 is false, so line 107 advances the cursor and line 108 reads the escaped character from one past the end of the buffer. The cursor then sits at `end + 1`, and because every loop in the parser tests `cur != end` rather than `cur < end`, parsing keeps walking forward through whatever follows the buffer. A dependency file whose last byte is a backslash, for example one truncated because the compiler was killed while writing it, makes llbuild read past the end of the buffer and crash.

I reproduced it by placing the input at the end of a mapped page with the following page set to `PROT_NONE` and parsing `a: b\`, which takes a fatal signal inside `MakefileDepsParser::parse()`. The same input in the googletest suite kills the test binary, with llbuild's own signal handler printing `MakefileDepsParser::parse()` at the top of the stack.

The same check also misses `\r\n` continuations, which `skipNonNewlineWhitespace()` already handles. When a backslash follows a word with no space in front of it, `out: in1\` CRLF `  in2` records the dependency as `in1\` followed by the carriage return and splits the logical line into two rules, while the identical input with `\n` correctly records `in1` and `in2`. When there is a space before the backslash, `skipNonNewlineWhitespace()` gets there first and both line endings already work, which is why the existing `out: \` CRLF `  in1` test passes.

The fix leaves `lexWord()` when the backslash is the last byte, and recognizes both `\n` and `\r\n` continuations, so the two functions that deal with a backslash agree. A backslash with nothing after it is now reported through the existing "unexpected character in prerequisites" path, the same way a trailing `$` already is. That seemed better than accepting it silently, since a depfile that ends mid-escape was truncated and its dependency list is incomplete.

Verified on macOS 26.2 arm64 with Apple clang 17, configured with `cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug`. `CoreTests` passes 22 of 22 with the change. Reverting only `lib/Core/MakefileDepsParser.cpp` and keeping the new assertions, `MakefileDepsParserTest.basic` fails the CRLF case with `("out", { "in1\r" })` where `("out", { "in1", "in2" })` is expected, and then dies on the truncated case. On the lit side, `tests/BuildSystem`, `tests/Ninja`, `tests/Commands` and `tests/Examples` give 135 passed, 6 unsupported and 1 failure, and that failure was my own partial build missing `libllbuild`; it passes once that target is built. The seven depfile tests, `discovered-makefile-deps`, `discovered-makefile-deps-relative`, `discovered-compiler-deps`, `makefile-implicit-deps`, `removed-makefile-implicit-dep`, `missing-depfile` and `absolute-dependencies`, all pass.

Nothing in the change is platform specific and it uses no C++ beyond the C++14 that `CMakeLists.txt` sets.
