### PR TITLE
[ninja] Deduplicate output nodes from commands

### DIFF
--- a/lib/Ninja/ManifestLoader.cpp
+++ b/lib/Ninja/ManifestLoader.cpp
@@ -19,6 +19,7 @@
 
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/raw_ostream.h"
@@ -314,7 +315,7 @@ public:
                       ArrayRef<Token> inputTokens,
                       unsigned numExplicitInputs,
                       unsigned numImplicitInputs,
-                      unsigned numExplicitOutputs) override {
+                      unsigned numExplicitOutputTokens) override {
     StringRef name(nameTok.start, nameTok.length);
 
     // Resolve the rule.
@@ -332,14 +333,32 @@ public:
     // Resolve all of the inputs and outputs.
     SmallVector<Node*, 8> outputs;
     SmallVector<NodeInCommand, 8> inputs;
-    for (const auto& token: outputTokens) {
+    SmallPtrSet<Node*, 8> seenOutputs;
+    unsigned numExplicitOutputs = numExplicitOutputTokens;
+    for (unsigned i = 0, e = unsigned(outputTokens.size()); i != e; ++i) {
+      const auto& token = outputTokens[i];
+      bool isExplicit = i < numExplicitOutputTokens;
       // Evaluate the token string.
       SmallString<256> path;
       evalString(token, getCurrentScope(), path);
       if (path.empty()) {
         error("empty output path", token);
       }
-      outputs.push_back(manifest->findOrCreateNode(workingDirectory, path));
+      Node *node = manifest->findOrCreateNode(workingDirectory, path);
+
+      // The same output can be named more than once in a build decl, e.g.
+      // when a build tool emits an explicit output using a relative path and
+      // an implicit output referring to the same file via an absolute path.
+      // Only record each unique output once; since explicit outputs are
+      // always listed before implicit ones, dropping a duplicate explicit
+      // token only ever collapses it into an earlier explicit entry.
+      if (!seenOutputs.insert(node).second) {
+        if (isExplicit)
+          --numExplicitOutputs;
+        continue;
+      }
+
+      outputs.push_back(node);
     }
     for (const auto& token: inputTokens) {
       // Evaluate the token string.

--- a/tests/Ninja/Build/duplicate-relative-absolute-output.ninja
+++ b/tests/Ninja/Build/duplicate-relative-absolute-output.ninja
@@ -1,0 +1,23 @@
+# Check that a build decl which lists the same output twice, once as an
+# explicit output using a relative path and once as an implicit output using
+# the absolute path to that same file (as cmake is known to generate), does
+# not cause llbuild to reject the manifest with a duplicate rule error.
+
+# We run the build in a sandbox in the temp directory to ensure we don't
+# interact with the source dirs.
+
+# RUN: rm -rf %t.build
+# RUN: mkdir -p %t.build
+# RUN: cp %s %t.build/build.ninja
+# RUN: touch %t.build/input
+# RUN: echo "build subdir/output | %t.build/subdir/output: CAT input" > %t.build/output-rule.ninja
+# RUN: %{llbuild} ninja build --jobs 1 --no-db --chdir %t.build &> %t.out
+# RUN: %{FileCheck} < %t.out %s
+# RUN: test -f %t.build/subdir/output
+
+# CHECK: [1/1] cat input > subdir/output
+
+rule CAT
+     command = cat ${in} > ${out}
+
+include output-rule.ninja


### PR DESCRIPTION
The same output can be named more than once in a build decl, e.g. when a build tool emits an explicit output using a relative path and an implicit output referring to the same file via an absolute path. Only record each unique output once.